### PR TITLE
Reset EventHub configuration in case of error

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -87,6 +87,18 @@ func NewClient(cfg *EventHubConfig) (*EventHubClient, error) {
 	return client, nil
 }
 
+func (c *EventHubClient) ResetConfig(cfg *EventHubConfig) error {
+	log.Info().Msg("Resetting EventHub Configuration")
+	hub, err := newHubFromConfig(cfg)
+	if err != nil {
+		log.ErrorObj(err).Msg("Failed to reset configuration")
+		return err
+	}
+
+	c.hub = hub
+	return nil
+}
+
 // Write creates and sends events from metric samples
 func (c *EventHubClient) Write(ctx context.Context, samples model.Samples) error {
 	// Stop processing if empty
@@ -111,6 +123,7 @@ func (c *EventHubClient) Write(ctx context.Context, samples model.Samples) error
 
 		if err := c.hub.SendBatch(ctx, eventhub.NewEventBatchIterator(events...)); err != nil {
 			log.ErrorObj(err).Msg("send event batch")
+			return err
 		}
 
 		duration := time.Since(begin).Seconds()

--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ type writer interface {
 	Write(ctx context.Context, samples model.Samples) error
 	Name() string
 	Close(ctx context.Context) error
+	ResetConfig(*hub.EventHubConfig) error
 }
 
 // logHandler initializes a gin logging middleware.
@@ -304,6 +305,9 @@ func sendSamples(ctx context.Context, w writer, samples model.Samples) error {
 	duration := time.Since(begin).Seconds()
 	if err != nil {
 		failedSamples.WithLabelValues(w.Name()).Add(float64(len(samples)))
+		// EventHub may have changed its ip appress
+		// reset the configuration to trigger a new dns resolution
+		w.ResetConfig(getWriterConfig())
 		return err
 	}
 


### PR DESCRIPTION
Re-configure the EventHub connection in case of error. EventHub sporadically changes its IP address and without a reconfiguration we will get stuck at connecting to the wrong IP.

We encountered this problem a bunch of times on an EventHub with auto inflate enabled. After some weeks of working correctly all ours prometheus-eventhubs-adapter pods were stuck with this error:

`{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.88:5671: read: connection reset by peer","timestamp":"2021-12-06T10:10:52Z","message":"send event batch"}
{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.XX:5671: read: connection reset by peer","timestamp":"2021-12-06T10:10:52Z","message":"send event batch"}
{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.XX:5671: read: connection reset by peer","timestamp":"2021-12-06T10:10:58Z","message":"send event batch"}
{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.XX:5671: read: connection reset by peer","timestamp":"2021-12-06T10:10:58Z","message":"send event batch"}
{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.XX:5671: read: connection reset by peer","timestamp":"2021-12-06T10:11:02Z","message":"send event batch"}
{"level":"error","error":"read tcp 10.240.0.13:41830->20.42.68.XX:5671: read: connection reset by peer","timestamp":"2021-12-06T10:11:02Z","message":"send event batch"}`

We discovered that EventHub had changed IP and we were pointing to the old one.

The Idea in this PR is to force a new configuration in the EH client in order to make it resolve again the DNS name in the connection string.